### PR TITLE
Fallback to single-line mark when caret positions are unavailable (py3.9-3.10)

### DIFF
--- a/tests/test_trace_cornercases.py
+++ b/tests/test_trace_cornercases.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from tests.hidden_module import internal_helper_function
 from tracerite.trace import (
     Range,
+    _fallback_mark_range_for_line,
     compute_cursor_position,
     extract_exception,
     extract_frames,
@@ -454,8 +455,8 @@ hidden_frame()
                     # In the new API, we also have a range field
                     range_obj = error_frame.get("range")
 
-                    # The error is raised on line 20 in _trigger_error_no_source
-                    expected_lineno = 20
+                    # The error is raised on line 21 in _trigger_error_no_source
+                    expected_lineno = 21
 
                     # Verify the range contains the correct line number
                     if range_obj:
@@ -1423,3 +1424,43 @@ class TestFormatLocation:
         assert location == "<unknown>", f"Expected '<unknown>', got '{location}'"
         assert filename is None, "Filename should remain None"
         assert urls == {}, "URLs should be empty dict"
+
+
+class TestFallbackMarkRange:
+    """Tests for fallback single-line marking when caret columns are missing."""
+
+    def test_fallback_trims_whitespace_and_comment(self):
+        """Whitespace and end-of-line comments are excluded from the mark."""
+        lines = "    x = 1  # comment\n"
+        result = _fallback_mark_range_for_line(lines, error_line_in_context=1)
+        assert result == Range(1, 1, 4, 9)
+
+    def test_fallback_no_comment(self):
+        """Trailing whitespace is trimmed when there is no comment."""
+        lines = "    y = 2   \n"
+        result = _fallback_mark_range_for_line(lines, error_line_in_context=1)
+        assert result == Range(1, 1, 4, 9)
+
+    def test_fallback_comment_only_line(self):
+        """A line that is only a comment gets a minimal one-character mark."""
+        lines = "    # just a comment\n"
+        result = _fallback_mark_range_for_line(lines, error_line_in_context=1)
+        assert result == Range(1, 1, 4, 5)
+
+    def test_fallback_whitespace_only_line(self):
+        """A line with no code produces no fallback mark."""
+        lines = "    \n"
+        result = _fallback_mark_range_for_line(lines, error_line_in_context=1)
+        assert result is None
+
+    def test_fallback_ignores_comment_in_string(self):
+        """A '#' inside a string does not end the marked region."""
+        lines = '    x = "a # b"  # comment\n'
+        result = _fallback_mark_range_for_line(lines, error_line_in_context=1)
+        assert result == Range(1, 1, 4, 15)
+
+    def test_fallback_out_of_range(self):
+        """An invalid line number produces no fallback mark."""
+        lines = "    x = 1\n"
+        assert _fallback_mark_range_for_line(lines, error_line_in_context=0) is None
+        assert _fallback_mark_range_for_line(lines, error_line_in_context=2) is None

--- a/tracerite/inspector.py
+++ b/tracerite/inspector.py
@@ -86,7 +86,7 @@ def _array_formatter(arr: Any) -> tuple[Callable[[Any], str], str]:
         finite = [abs(v) for v in sample if v == v and abs(v) != float("inf")]
         if not finite:
             # All NaN/Inf
-            return lambda v: ("NaN" if v != v else ("∞" if v > 0 else "-∞")), ""
+            return lambda v: "NaN" if v != v else ("∞" if v > 0 else "-∞"), ""
 
         max_abs = max(finite) if finite else 0
         log_max = math.log10(max_abs) if max_abs > 0 else 0

--- a/tracerite/trace.py
+++ b/tracerite/trace.py
@@ -1168,9 +1168,9 @@ def _get_variable_source_for_comprehension(
 def _fallback_mark_range_for_line(lines, error_line_in_context):
     """Build a single-line mark Range when caret columns are unavailable.
 
-    Trims leading/trailing whitespace and end-of-line comments so that the
-    whole meaningful code portion of the error line is highlighted.
-    Returns a Range or None.
+    Trims leading/trailing whitespace and (when present) end-of-line comments so that
+    the meaningful portion of the line is highlighted. For comment-only lines, a
+    minimal one-character mark is returned; for whitespace-only lines, returns None.
     """
     lines_list = lines.splitlines(keepends=True)
     if not (1 <= error_line_in_context <= len(lines_list)):

--- a/tracerite/trace.py
+++ b/tracerite/trace.py
@@ -1165,6 +1165,35 @@ def _get_variable_source_for_comprehension(
     return marked_text or lines
 
 
+def _fallback_mark_range_for_line(lines, error_line_in_context):
+    """Build a single-line mark Range when caret columns are unavailable.
+
+    Trims leading/trailing whitespace and end-of-line comments so that the
+    whole meaningful code portion of the error line is highlighted.
+    Returns a Range or None.
+    """
+    lines_list = lines.splitlines(keepends=True)
+    if not (1 <= error_line_in_context <= len(lines_list)):
+        return None
+    line = lines_list[error_line_in_context - 1]
+    content, _ = _split_line_content(line)
+    stripped = content.lstrip()
+    if not stripped:
+        return None
+    start_col = len(content) - len(stripped)
+
+    comment_start = _find_comment_start(content)
+    if comment_start is not None:
+        code_end = content[:comment_start].rstrip()
+        end_col = len(code_end)
+    else:
+        end_col = len(content.rstrip())
+
+    if end_col <= start_col:
+        end_col = start_col + 1
+    return Range(error_line_in_context, error_line_in_context, start_col, end_col)
+
+
 def _extract_emphasis_columns(
     lines, error_line_in_context, end_line, start_col, end_col, start
 ):
@@ -1498,6 +1527,10 @@ def extract_frames(tb, raw_tb=None, *, except_block=False, exc=None) -> list:
             mark_range = Range(
                 error_line_in_context, mark_lfinal, adjusted_start_col, adjusted_end_col
             )
+        elif error_line_in_context:
+            # Fallback for Python versions that don't provide caret positions:
+            # highlight the trimmed error line so there is always a visible mark.
+            mark_range = _fallback_mark_range_for_line(lines, error_line_in_context)
 
         # Build emphasis range and fragments
         em_range = _extract_emphasis_columns(


### PR DESCRIPTION
On Python <=3.10 code.co_positions() is not available, so extract_frames() received no column info and produced no mark/highlight at all. Add a fallback that builds a mark Range from the known error line, trimming leading/trailing whitespace and end-of-line comments (but not '#' inside strings).