### PR TITLE
Show skip count in shortened call chains in HTML output

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -387,11 +387,11 @@ def test_collapse_call_runs_final_run_collapsed():
 
     result = _collapse_call_runs(frames)
 
-    # Should have: error frame, first call frame, ..., last call frame
+    # Should have: error frame, first call frame, ellipsis with count, last call frame
     expected = [
         {"relevance": "error", "id": 1},
         {"relevance": "call", "id": 2},  # First of the run
-        ...,  # Ellipsis
+        (..., 10),  # 10 calls skipped between first and last
         {"relevance": "call", "id": 13},  # Last of the run
     ]
     assert result == expected

--- a/tests/test_html_cornercases.py
+++ b/tests/test_html_cornercases.py
@@ -104,8 +104,8 @@ class TestHtmlCornercases:
             html = html_traceback(exc=e)
             html_str = str(html)
 
-            # Should contain ellipsis when frames are limited
-            assert "..." in html_str
+            # Should contain skipped call count when frames are limited
+            assert "more calls" in html_str
 
     def test_exception_with_no_frames(self):
         """Test HTML rendering when exception has no frames."""

--- a/tracerite/html.py
+++ b/tracerite/html.py
@@ -40,9 +40,9 @@ def _collapse_call_runs(
             if run_start is not None:
                 run_length = i - run_start
                 if run_length >= min_run_length:
-                    # Keep first and last of the run, add ellipsis
+                    # Keep first and last of the run, add ellipsis with count
                     result.append(frames[run_start])
-                    result.append(...)
+                    result.append((..., run_length - 2))
                     result.append(frames[i - 1])
                 else:
                     # Run too short, keep all
@@ -56,7 +56,7 @@ def _collapse_call_runs(
         run_length = len(frames) - run_start
         if run_length >= min_run_length:
             result.append(frames[run_start])
-            result.append(...)
+            result.append((..., run_length - 2))
             result.append(frames[-1])
         else:
             result.extend(frames[run_start:])
@@ -134,8 +134,9 @@ def _render_frame_list(
     limited_frames = _collapse_call_runs(frames, min_run_length=10)
 
     for frinfo in limited_frames:
-        if frinfo is ...:
-            doc.p("...", class_="traceback-ellipsis")
+        if isinstance(frinfo, tuple) and frinfo[0] is ...:
+            skipped = frinfo[1]
+            doc.p(f"⋮ {skipped} more calls", class_="traceback-ellipsis")
             continue
 
         relevance = frinfo["relevance"]


### PR DESCRIPTION
- Matches TTY output
