### PR TITLE
Proper handling of re-raised exceptions

### DIFF
--- a/tests/errorcases.py
+++ b/tests/errorcases.py
@@ -323,6 +323,46 @@ def deeply_nested_chain_with_calls():
         raise  # Re-raise so caller can catch it
 
 
+def _raise_typeerror_in_except():
+    """Helper: raises TypeError while handling a ZeroDivisionError."""
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        raise TypeError("handler failed")
+
+
+def _reraise_same_exception():
+    """Middle hop: re-raises the caught exception with ``raise e``."""
+    try:
+        _raise_typeerror_in_except()
+    except TypeError as e:
+        raise e
+
+
+def reraise_same_exception_in_chain():
+    """Three-exception chain with a middle hop doing ``raise e``.
+
+    The ``raise e`` frame must render after the TypeError crash site, not
+    before the calls that led to it.
+    """
+    try:
+        _reraise_same_exception()
+    except TypeError as e:
+        raise RuntimeError("wrapped") from e
+
+
+def reraise_outermost_exception():
+    """Both hops re-raise the caught exception with ``raise e``.
+
+    The outermost re-raise is the final frame and must carry the TypeError
+    banner; the crash site keeps error relevance without the banner.
+    """
+    try:
+        _reraise_same_exception()
+    except TypeError as e:
+        raise e
+
+
 # ---------------------------------------------------------------------------
 # With-block enter/exit failures (context extension and statement marking)
 # ---------------------------------------------------------------------------

--- a/tests/test_trace_chain_analysis.py
+++ b/tests/test_trace_chain_analysis.py
@@ -627,9 +627,7 @@ class TestBuildChronologicalFrames:
         chrono = build_chronological_frames(chain)
 
         # Exception banners stay in chronological order
-        exc_types = [
-            f["exception"]["type"] for f in chrono if f.get("exception")
-        ]
+        exc_types = [f["exception"]["type"] for f in chrono if f.get("exception")]
         assert exc_types == ["ZeroDivisionError", "TypeError", "RuntimeError"]
 
         # The middle hop appears twice: the call, and the ``raise e`` frame
@@ -663,12 +661,11 @@ class TestBuildChronologicalFrames:
 
         # The crash site keeps error relevance but loses the banner.
         crash = next(
-            f
-            for f in chrono
-            if "raise TypeError" in (f.get("codeline") or "")
+            f for f in chrono if "raise TypeError" in (f.get("codeline") or "")
         )
         assert crash["relevance"] == "error"
         assert not crash.get("exception")
+        assert crash["symbol_desc"] == "TypeError"
 
     def test_reraise_outermost_keeps_banner_on_last_frame(self):
         """A ``raise e`` of the outermost exception carries its banner last.
@@ -702,17 +699,14 @@ class TestBuildChronologicalFrames:
         ]
 
         # Exception banners are in chronological order, crash keeps 💣.
-        exc_types = [
-            f["exception"]["type"] for f in chrono if f.get("exception")
-        ]
+        exc_types = [f["exception"]["type"] for f in chrono if f.get("exception")]
         assert exc_types == ["ZeroDivisionError", "TypeError"]
         crash = next(
-            f
-            for f in chrono
-            if "raise TypeError" in (f.get("codeline") or "")
+            f for f in chrono if "raise TypeError" in (f.get("codeline") or "")
         )
         assert crash["relevance"] == "error"
         assert not crash.get("exception")
+        assert crash["symbol_desc"] == "TypeError"
 
     def test_find_re_raise_frames_before_link(self):
         """In-except frames whose function reappears later are re-raises."""
@@ -720,15 +714,30 @@ class TestBuildChronologicalFrames:
             {"filename": "a.py", "function": "outer", "lineno": 10},
             {"filename": "a.py", "function": "mid", "lineno": 20, "_except_start": 18},
             {"filename": "a.py", "function": "mid", "lineno": 15},
-            {"filename": "a.py", "function": "inner", "lineno": 30, "_except_start": 28},
+            {
+                "filename": "a.py",
+                "function": "inner",
+                "lineno": 30,
+                "_except_start": 28,
+            },
         ]
         assert find_re_raise_frames_before_link(frames, 3) == [1]
 
     def test_find_re_raise_frames_before_link_keeps_except_call(self):
         """A call from an except handler is not a re-raise without a duplicate."""
         frames = [
-            {"filename": "a.py", "function": "caller", "lineno": 20, "_except_start": 18},
-            {"filename": "a.py", "function": "inner", "lineno": 30, "_except_start": 28},
+            {
+                "filename": "a.py",
+                "function": "caller",
+                "lineno": 20,
+                "_except_start": 18,
+            },
+            {
+                "filename": "a.py",
+                "function": "inner",
+                "lineno": 30,
+                "_except_start": 28,
+            },
         ]
         assert find_re_raise_frames_before_link(frames, 1) == []
 

--- a/tests/test_trace_chain_analysis.py
+++ b/tests/test_trace_chain_analysis.py
@@ -19,6 +19,7 @@ from tracerite.trace.order import (
     enrich_chain_with_links,
     filter_hidden_frames,
     find_chain_link,
+    find_re_raise_frames_before_link,
     frame_in_except_handler,
     get_frame_lineno,
 )
@@ -28,6 +29,8 @@ from .errorcases import (
     deeply_nested_chain_with_calls,
     error_via_call_in_except,
     reraise_context,
+    reraise_outermost_exception,
+    reraise_same_exception_in_chain,
     unrelated_error_in_except,
 )
 
@@ -607,6 +610,127 @@ class TestBuildChronologicalFrames:
         assert (
             exc_frames[2]["exception"]["from"] == "context"
         )  # ZeroDivisionError - implicit
+
+    def test_reraise_same_exception_frame_moves_after_crash(self):
+        """A ``raise e`` frame renders after the crash site, not before it.
+
+        The middle hop re-raises the caught exception, prepending a frame at
+        the ``raise e`` line while its original call frame stays deeper in
+        the traceback.  Chronologically the re-raise happened after the
+        TypeError was raised, so it must follow the crash frame.
+        """
+        try:
+            reraise_same_exception_in_chain()
+        except Exception as e:
+            chain = extract_chain_exceptions(e)
+
+        chrono = build_chronological_frames(chain)
+
+        # Exception banners stay in chronological order
+        exc_types = [
+            f["exception"]["type"] for f in chrono if f.get("exception")
+        ]
+        assert exc_types == ["ZeroDivisionError", "TypeError", "RuntimeError"]
+
+        # The middle hop appears twice: the call, and the ``raise e`` frame
+        mid = [
+            i
+            for i, f in enumerate(chrono)
+            if f.get("function") == "_reraise_same_exception"
+        ]
+        assert len(mid) == 2
+        call_idx, reraise_idx = mid
+        assert chrono[call_idx]["relevance"] == "call"
+        assert chrono[reraise_idx]["relevance"] == "except"
+        assert chrono[reraise_idx]["function_suffix"] == "⚡except"
+        assert chrono[reraise_idx]["symbol_desc"] == "Re-raise"
+
+        zde_idx = next(
+            i
+            for i, f in enumerate(chrono)
+            if (f.get("exception") or {}).get("type") == "ZeroDivisionError"
+        )
+        typeerror_idx = next(
+            i
+            for i, f in enumerate(chrono)
+            if (f.get("exception") or {}).get("type") == "TypeError"
+        )
+
+        # Call leads to the crash; the re-raise follows the crash site and
+        # carries the exception banner as the last frame of its section.
+        assert call_idx < zde_idx < typeerror_idx
+        assert typeerror_idx == reraise_idx
+
+        # The crash site keeps error relevance but loses the banner.
+        crash = next(
+            f
+            for f in chrono
+            if "raise TypeError" in (f.get("codeline") or "")
+        )
+        assert crash["relevance"] == "error"
+        assert not crash.get("exception")
+
+    def test_reraise_outermost_keeps_banner_on_last_frame(self):
+        """A ``raise e`` of the outermost exception carries its banner last.
+
+        With two re-raise hops the traceback stores them most-recent-first,
+        so chronological order emits them reversed: the middle hop's frame
+        precedes the outermost one, which closes the chain with the banner.
+        """
+        try:
+            reraise_outermost_exception()
+        except Exception as e:
+            chain = extract_chain_exceptions(e)
+
+        chrono = build_chronological_frames(chain)
+
+        # The outermost re-raise is the final frame and carries the banner.
+        assert chrono[-1]["function"] == "reraise_outermost_exception"
+        assert chrono[-1]["relevance"] == "except"
+        assert chrono[-1]["symbol_desc"] == "Re-raise"
+        assert chrono[-1]["exception"]["type"] == "TypeError"
+
+        # The middle re-raise renders before the outermost one.
+        reraises = [
+            (f.get("function"), f.get("symbol_desc"))
+            for f in chrono
+            if f.get("symbol_desc") == "Re-raise"
+        ]
+        assert reraises == [
+            ("_reraise_same_exception", "Re-raise"),
+            ("reraise_outermost_exception", "Re-raise"),
+        ]
+
+        # Exception banners are in chronological order, crash keeps 💣.
+        exc_types = [
+            f["exception"]["type"] for f in chrono if f.get("exception")
+        ]
+        assert exc_types == ["ZeroDivisionError", "TypeError"]
+        crash = next(
+            f
+            for f in chrono
+            if "raise TypeError" in (f.get("codeline") or "")
+        )
+        assert crash["relevance"] == "error"
+        assert not crash.get("exception")
+
+    def test_find_re_raise_frames_before_link(self):
+        """In-except frames whose function reappears later are re-raises."""
+        frames = [
+            {"filename": "a.py", "function": "outer", "lineno": 10},
+            {"filename": "a.py", "function": "mid", "lineno": 20, "_except_start": 18},
+            {"filename": "a.py", "function": "mid", "lineno": 15},
+            {"filename": "a.py", "function": "inner", "lineno": 30, "_except_start": 28},
+        ]
+        assert find_re_raise_frames_before_link(frames, 3) == [1]
+
+    def test_find_re_raise_frames_before_link_keeps_except_call(self):
+        """A call from an except handler is not a re-raise without a duplicate."""
+        frames = [
+            {"filename": "a.py", "function": "caller", "lineno": 20, "_except_start": 18},
+            {"filename": "a.py", "function": "inner", "lineno": 30, "_except_start": 28},
+        ]
+        assert find_re_raise_frames_before_link(frames, 1) == []
 
     def test_inner_exception_without_frames(self):
         """Test chronological frames when inner exception has no frames.

--- a/tests/test_trace_chain_analysis.py
+++ b/tests/test_trace_chain_analysis.py
@@ -741,6 +741,31 @@ class TestBuildChronologicalFrames:
         ]
         assert find_re_raise_frames_before_link(frames, 1) == []
 
+    def test_find_re_raise_frames_before_link_ignores_missing_identity(self):
+        """Frames without filename or function never match as re-raises."""
+        frames = [
+            {"function": "mid", "lineno": 20, "_except_start": 18},
+            {"function": "mid", "lineno": 15},
+            {
+                "filename": "a.py",
+                "function": "inner",
+                "lineno": 30,
+                "_except_start": 28,
+            },
+        ]
+        assert find_re_raise_frames_before_link(frames, 2) == []
+        frames = [
+            {"filename": "a.py", "lineno": 20, "_except_start": 18},
+            {"filename": "a.py", "lineno": 15},
+            {
+                "filename": "a.py",
+                "function": "inner",
+                "lineno": 30,
+                "_except_start": 28,
+            },
+        ]
+        assert find_re_raise_frames_before_link(frames, 2) == []
+
     def test_inner_exception_without_frames(self):
         """Test chronological frames when inner exception has no frames.
 

--- a/tracerite/trace/order.py
+++ b/tracerite/trace/order.py
@@ -352,7 +352,9 @@ def build_linked_backbone(
             promote_to_except(chrono_frame)
         if frame_idx == last_idx:
             add_subexceptions_to_frame(chrono_frame, exc, cache=cache)
-            if not re_raise:
+            if re_raise:
+                chrono_frame["symbol_desc"] = exc["type"]
+            else:
                 chrono_frame["exception"] = banner
 
     # Re-raise entries are prepended to the traceback as the exception

--- a/tracerite/trace/order.py
+++ b/tracerite/trace/order.py
@@ -326,8 +326,13 @@ def build_linked_backbone(
     inner_exc = chain[inner_exc_idx]
     inner_frames = inner_exc.get("frames", [])
 
+    # ``raise e`` on the caught exception prepends a frame entry that happened
+    # after the crash site; emit those after it instead of with the calls.
+    re_raise = find_re_raise_frames_before_link(frames, except_frame_idx, cache=cache)
+
     for frame_idx in range(except_frame_idx):
-        append_copied_frame(chronological, frames[frame_idx])
+        if frame_idx not in re_raise:
+            append_copied_frame(chronological, frames[frame_idx])
 
     build_backbone_frames(
         chronological,
@@ -340,13 +345,27 @@ def build_linked_backbone(
     )
 
     last_idx = len(frames) - 1
+    banner = make_exception_banner(exc, exc_idx)
     for frame_idx in range(except_frame_idx, len(frames)):
         chrono_frame = append_copied_frame(chronological, frames[frame_idx])
         if frame_idx == except_frame_idx:
             promote_to_except(chrono_frame)
         if frame_idx == last_idx:
-            chrono_frame["exception"] = make_exception_banner(exc, exc_idx)
             add_subexceptions_to_frame(chrono_frame, exc, cache=cache)
+            if not re_raise:
+                chrono_frame["exception"] = banner
+
+    # Re-raise entries are prepended to the traceback as the exception
+    # unwinds, so their traceback order is reverse-chronological.
+    for frame_idx in reversed(re_raise):
+        chrono_frame = append_copied_frame(chronological, frames[frame_idx])
+        promote_to_except(chrono_frame)
+        chrono_frame["symbol_desc"] = "Re-raise"
+
+    if re_raise:
+        # The banner belongs to the last frame of this exception's section;
+        # the crash site keeps its error relevance either way.
+        chronological[-1]["exception"] = banner
 
 
 def build_unlinked_backbone(
@@ -408,6 +427,42 @@ def find_re_raise_frames(
         for i, frame in enumerate(frames[:-1])
         if frame_in_except_handler(frame, cache=cache)
     ]
+
+
+def find_re_raise_frames_before_link(
+    frames: list[FrameInfo],
+    except_frame_idx: int,
+    *,
+    cache: dict | None = None,
+) -> list[int]:
+    """Find frames before the chain link that re-raise the same exception.
+
+    ``raise e`` on the caught exception prepends a traceback entry at the
+    ``raise`` line while the original call entry of the same function stays
+    deeper in the traceback.  Such entries are inside an except handler and
+    their function appears again later in the traceback; chronologically
+    they happened after the exception's crash site, not before the calls
+    that led to it.
+    """
+    re_raise = []
+    for frame_idx in range(except_frame_idx):
+        frame = frames[frame_idx]
+        if not frame_in_except_handler(frame, cache=cache):
+            continue
+        identity = (
+            frame.get("original_filename") or frame.get("filename"),
+            frame.get("function"),
+        )
+        if any(
+            (
+                other.get("original_filename") or other.get("filename"),
+                other.get("function"),
+            )
+            == identity
+            for other in frames[frame_idx + 1 :]
+        ):
+            re_raise.append(frame_idx)
+    return re_raise
 
 
 def make_exception_banner(exc: ExceptionInfo, exc_idx: int) -> ExceptionInfo:

--- a/tracerite/trace/order.py
+++ b/tracerite/trace/order.py
@@ -329,9 +329,10 @@ def build_linked_backbone(
     # ``raise e`` on the caught exception prepends a frame entry that happened
     # after the crash site; emit those after it instead of with the calls.
     re_raise = find_re_raise_frames_before_link(frames, except_frame_idx, cache=cache)
+    skipped = frozenset(re_raise)
 
     for frame_idx in range(except_frame_idx):
-        if frame_idx not in re_raise:
+        if frame_idx not in skipped:
             append_copied_frame(chronological, frames[frame_idx])
 
     build_backbone_frames(
@@ -396,7 +397,8 @@ def build_unlinked_backbone(
             )
 
     re_raise = find_re_raise_frames(exc, frames, cache=cache)
-    order = [i for i in range(len(frames)) if i not in re_raise] + re_raise
+    skipped = frozenset(re_raise)
+    order = [i for i in range(len(frames)) if i not in skipped] + re_raise
     last_idx = len(frames) - 1
     banner = make_exception_banner(exc, exc_idx)
 
@@ -411,7 +413,7 @@ def build_unlinked_backbone(
                 chrono_frame["exception"] = banner
         if is_final and re_raise:
             chrono_frame["exception"] = banner
-        if frame_idx in re_raise:
+        if frame_idx in skipped:
             promote_to_except(chrono_frame)
 
 
@@ -446,24 +448,24 @@ def find_re_raise_frames_before_link(
     they happened after the exception's crash site, not before the calls
     that led to it.
     """
+    seen: set[tuple[str | None, str | None]] = set()
     re_raise = []
-    for frame_idx in range(except_frame_idx):
+    for frame_idx in range(len(frames) - 1, -1, -1):
         frame = frames[frame_idx]
-        if not frame_in_except_handler(frame, cache=cache):
-            continue
         identity = (
             frame.get("original_filename") or frame.get("filename"),
             frame.get("function"),
         )
-        if any(
-            (
-                other.get("original_filename") or other.get("filename"),
-                other.get("function"),
-            )
-            == identity
-            for other in frames[frame_idx + 1 :]
+        if None in identity:
+            continue
+        if (
+            frame_idx < except_frame_idx
+            and identity in seen
+            and frame_in_except_handler(frame, cache=cache)
         ):
             re_raise.append(frame_idx)
+        seen.add(identity)
+    re_raise.reverse()
     return re_raise
 
 

--- a/tracerite/tty.py
+++ b/tracerite/tty.py
@@ -734,16 +734,21 @@ def _build_chrono_frame_lines(
 
     start = frinfo.get("linenostart", 1)
     symbol = symbols.get(relevance, "")
-    symbol_colored = f"{EM_CALL}{symbol}{RESET}" if symbol else ""
-
     desc = frinfo.get("symbol_desc") or symdesc[relevance]
+    symbol_colored = f"{EM_CALL}{symbol}{RESET}" if symbol else ""
+    symbol_suffix = (
+        f"{symbol_colored} {SYMBOLDESC}{desc}{RESET}"
+        if desc
+        else symbol_colored
+        if symbol
+        else ""
+    )
 
     # Width available for the content after the left border "│ "
     content_width = max(1, term_width - _LINE_PREFIX_WIDTH)
     single_marked = len(info["marked_lines"]) == 1
 
     raw_lines: list[tuple[str, bool, bool]] = []
-    symbol_suffix = f"{symbol_colored} {SYMBOLDESC}{desc}{RESET}" if symbol else ""
 
     if not fragments:
         # Show "(no source code)" with the symbol emoji like a code line would have
@@ -1167,7 +1172,7 @@ def _merge_chrono_output(
             _LINE_PREFIX_WIDTH + 2,
             term_width - min_content_width - 4,
         )
-        inspector_col = min(max_line_len + 2, max_inspector_col)
+        inspector_col = min(max_line_len + 3, max_inspector_col)
 
         # Calculate available space - inspector must not overlap with code
         # Available = term_width - inspector_col - 4 (for box/arrow chars)


### PR DESCRIPTION
* Fixed chronological frame ordering
* Moved exception banner from original raise to after all re-raises
* Bomb symbol appears on original position with exception type after it
* Warning re-raises are shown on any frames that follow
* Exception banner renders at the end (after possible modification by re-raise frames)
